### PR TITLE
Add ability to specify versions of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ jobs:
 - `install-kubectl` : Install kubectl. Default `yes`
 - `install-helm` : Install Helm. Default `yes`
 - `install-helm-plugins` : Install Helm plugins. Default `yes`
+- `helm-diff-plugin-version` : Plugin version to install. Default `master`
+- `helm-s3-plugin-version` : Plugin version to install. Default `master`
 - `additional-helm-plugins` : A comma separated list of additional helm plugins to install. Should be a valid argument after `helm plugin install`.
 
 > See "[Installing kubectl - Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html)" for information how to specify the kubectl version.

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: "Install Helm plugins"
     default: "yes"
     required: false
+  helm-diff-plugin-version:
+    description: "Version of the helm diff plugin to install"
+    default: "master"
+    required: false
+  helm-s3-plugin-version:
+    description: "Version of the helm s3 plugin to install"
+    default: "master"
+    required: false
   additional-helm-plugins:
     description: |
       A comma separated list of additional helm plugins to install. Should be a valid argument after `helm plugin install`.

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ async function run() {
     }
     if (core.getInput("install-helm-plugins") === "yes") {
       installHelmPlugins([
-        'https://github.com/databus23/helm-diff --version master',
-        'https://github.com/hypnoglow/helm-s3.git',
+        'https://github.com/databus23/helm-diff --version ' + core.getInput("helm-diff-plugin-version"),
+        'https://github.com/hypnoglow/helm-s3.git --version ' + core.getInput("helm-s3-plugin-version"),
       ]);
     }
     const additionalPlugins = core.getInput("additional-helm-plugins")


### PR DESCRIPTION
Backward compatibility is maintained with both plugins installed at `master` version. However users who wish to manage these versions explicitly are now able to do so.