### PR TITLE
chore: allow pulling helmfile releases from new helmfile repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ jobs:
 ```
 
 ## Optional Inputs
-- `helmfile-version` : helmfile version. Default `"v0.142.0"`.
-- `helm-version` : Helm version. Default `"v3.7.1"`
-- `kubectl-version` : kubectl version. Default `1.21.2`
-- `kubectl-release-date` : kubectl release date. Default `2021-07-05`
+- `helmfile-version` : helmfile version. Default `"v0.145.0"`.
+- `helm-version` : Helm version. Default `"v3.7.2"`
+- `kubectl-version` : kubectl version. Default `1.22.9`
+- `kubectl-release-date` : kubectl release date. Default `2022-06-03`
 - `install-kubectl` : Install kubectl. Default `yes`
 - `install-helm` : Install Helm. Default `yes`
 - `install-helm-plugins` : Install Helm plugins. Default `yes`
@@ -57,7 +57,7 @@ jobs:
         helmfile-version: "v0.135.0"
 ```
 
-If you are not particular about the version of kubectl / Helm and you can use the versions pre-installed on GitHub Actions runner, you can specify inputs not to install them. 
+If you are not particular about the version of kubectl / Helm and you can use the versions pre-installed on GitHub Actions runner, you can specify inputs not to install them.
 
 > Notice: Helm plugins will be installed in this case.
 

--- a/action.yml
+++ b/action.yml
@@ -7,19 +7,19 @@ branding:
 inputs:
   kubectl-version:
     description: "kubectl (AWS edition) version"
-    default: "1.21.2"
+    default: "1.22.9"
     required: false
   kubectl-release-date:
     description: "kubectl (AWS edition) release date"
-    default: "2021-07-05"
+    default: "2022-06-03"
     required: false
   helm-version:
     description: "Helm version"
-    default: "v3.7.1"
+    default: "v3.9.0"
     required: false
   helmfile-version:
     description: "helmfile version"
-    default: "v0.142.0"
+    default: "v0.145.0"
     required: false
   install-kubectl:
     description: "Install kubectl"

--- a/dist/index.js
+++ b/dist/index.js
@@ -4988,12 +4988,24 @@ async function installHelmPlugins(plugins) {
 
 async function installHelmfile(version) {
   if (semvercompare(version.replace(/^v/,''), "0.145.0") >= 0) {
-    var baseUrl = "https://github.com/helmfile/helmfile/releases/download"
+    await installHelmfileNew(version);
   } else {
-    var baseUrl = "https://github.com/roboll/helmfile/releases/download"
+    await installHelmfileOld(version);
   }
+}
+
+async function installHelmfileOld(version) {
+  const baseUrl = "https://github.com/roboll/helmfile/releases/download"
   const downloadPath = await download(`${baseUrl}/${version}/helmfile_linux_amd64`);
   await install(downloadPath, "helmfile");
+}
+
+async function installHelmfileNew(version) {
+  const baseUrl = "https://github.com/helmfile/helmfile/releases/download"
+  const downloadPath = await download(`${baseUrl}/${version}/helmfile_${version.replace(/^v/,'')}_linux_amd64.tar.gz`)
+  const folder = await extract(downloadPath);
+  console.log(folder);
+  await install(`${folder}/helmfile`, "helmfile");
 }
 
 async function download(url) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3691,6 +3691,26 @@ exports.getIDToken = getIDToken;
 
 /***/ }),
 
+/***/ 523:
+/***/ (function(module) {
+
+module.exports = function cmp (a, b) {
+    var pa = a.split('.');
+    var pb = b.split('.');
+    for (var i = 0; i < 3; i++) {
+        var na = Number(pa[i]);
+        var nb = Number(pb[i]);
+        if (na > nb) return 1;
+        if (nb > na) return -1;
+        if (!isNaN(na) && isNaN(nb)) return 1;
+        if (isNaN(na) && !isNaN(nb)) return -1;
+    }
+    return 0;
+};
+
+
+/***/ }),
+
 /***/ 533:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -4945,6 +4965,7 @@ const exec = __webpack_require__(986);
 const io = __webpack_require__(1);
 const path = __webpack_require__(622);
 const os = __webpack_require__(87);
+const semvercompare = __webpack_require__(523);
 
 async function installKubectl(version, releaseDate) {
   const baseUrl = "https://amazon-eks.s3-us-west-2.amazonaws.com";
@@ -4966,7 +4987,11 @@ async function installHelmPlugins(plugins) {
 }
 
 async function installHelmfile(version) {
-  const baseUrl = "https://github.com/roboll/helmfile/releases/download"
+  if (semvercompare(version.replace(/^v/,''), "0.145.0") >= 0) {
+    var baseUrl = "https://github.com/helmfile/helmfile/releases/download"
+  } else {
+    var baseUrl = "https://github.com/roboll/helmfile/releases/download"
+  }
   const downloadPath = await download(`${baseUrl}/${version}/helmfile_linux_amd64`);
   await install(downloadPath, "helmfile");
 }
@@ -5204,7 +5229,7 @@ async function run() {
       installKubectl(core.getInput("kubectl-version"), core.getInput("kubectl-release-date"));
     }
     if (core.getInput("install-helm") === "yes") {
-      installHelm(core.getInput("helm-version"));
+      await installHelm(core.getInput("helm-version"));
     }
     if (core.getInput("install-helm-plugins") === "yes") {
       installHelmPlugins([

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "setup-helmfile",
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
@@ -12,7 +13,8 @@
         "@actions/exec": "^1.1.0",
         "@actions/github": "^5.0.0",
         "@actions/io": "^1.1.1",
-        "@actions/tool-cache": "^1.7.1"
+        "@actions/tool-cache": "^1.7.1",
+        "semver-compare": "^1.0.0"
       },
       "devDependencies": {
         "@zeit/ncc": "^0.22.3",
@@ -4168,6 +4170,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8029,6 +8036,11 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
     "@actions/io": "^1.1.1",
-    "@actions/tool-cache": "^1.7.1"
+    "@actions/tool-cache": "^1.7.1",
+    "semver-compare": "^1.0.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",

--- a/src/setup.js
+++ b/src/setup.js
@@ -26,7 +26,7 @@ async function installHelmPlugins(plugins) {
 }
 
 async function installHelmfile(version) {
-  if (semvercompare(version, "0.145.0") >= 0) {
+  if (semvercompare(version.replace(/^v/,''), "0.145.0") >= 0) {
     var baseUrl = "https://github.com/helmfile/helmfile/releases/download"
   } else {
     var baseUrl = "https://github.com/roboll/helmfile/releases/download"

--- a/src/setup.js
+++ b/src/setup.js
@@ -26,7 +26,7 @@ async function installHelmPlugins(plugins) {
 }
 
 async function installHelmfile(version) {
-  if (semvercompare(version.replace(/^v/,), "0.145.0") >= 0) {
+  if (semvercompare(version.replace(/^v/,''), "0.145.0") >= 0) {
     await installHelmfileNew(version);
   } else {
     await installHelmfileOld(version);

--- a/src/setup.js
+++ b/src/setup.js
@@ -26,13 +26,25 @@ async function installHelmPlugins(plugins) {
 }
 
 async function installHelmfile(version) {
-  if (semvercompare(version.replace(/^v/,''), "0.145.0") >= 0) {
-    var baseUrl = "https://github.com/helmfile/helmfile/releases/download"
+  if (semvercompare(version.replace(/^v/,), "0.145.0") >= 0) {
+    await installHelmfileNew(version);
   } else {
-    var baseUrl = "https://github.com/roboll/helmfile/releases/download"
+    await installHelmfileOld(version);
   }
+}
+
+async function installHelmfileOld(version) {
+  const baseUrl = "https://github.com/roboll/helmfile/releases/download"
   const downloadPath = await download(`${baseUrl}/${version}/helmfile_linux_amd64`);
   await install(downloadPath, "helmfile");
+}
+
+async function installHelmfileNew(version) {
+  const baseUrl = "https://github.com/helmfile/helmfile/releases/download"
+  const downloadPath = await download(`${baseUrl}/${version}/helmfile_${version.replace(/^v/,'')}_linux_amd64.tar.gz`)
+  const folder = await extract(downloadPath);
+  console.log(folder);
+  await install(`${folder}/helmfile`, "helmfile");
 }
 
 async function download(url) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -4,6 +4,7 @@ const exec = require("@actions/exec");
 const io = require("@actions/io");
 const path = require("path");
 const os = require("os");
+const semvercompare = require("semver-compare");
 
 async function installKubectl(version, releaseDate) {
   const baseUrl = "https://amazon-eks.s3-us-west-2.amazonaws.com";
@@ -25,7 +26,11 @@ async function installHelmPlugins(plugins) {
 }
 
 async function installHelmfile(version) {
-  const baseUrl = "https://github.com/roboll/helmfile/releases/download"
+  if (semvercompare(version, "0.145.0") >= 0) {
+    var baseUrl = "https://github.com/helmfile/helmfile/releases/download"
+  } else {
+    var baseUrl = "https://github.com/roboll/helmfile/releases/download"
+  }
   const downloadPath = await download(`${baseUrl}/${version}/helmfile_linux_amd64`);
   await install(downloadPath, "helmfile");
 }


### PR DESCRIPTION
Also bumps the default versions of all tools.

Uses the `semver-compare` library to check whether we are installing version 0.145.0 or later; if so, we use the new repository. Otherwise, we use the old repository.