### PR TITLE
Upgrade to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ inputs:
       A comma separated list of additional helm plugins to install. Should be a valid argument after `helm plugin install`.
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
node12 is deprecated
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

When I use `mamezou-tech/setup-helmfile` , I will get the following deprecation warning

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: mamezou-tech/setup-helmfile

So I upgraded to node16

This works on my repository