### PR TITLE
Trim additional helm plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ async function run() {
     }
     const additionalPlugins = core.getInput("additional-helm-plugins")
     if (additionalPlugins !== "") {
-      installHelmPlugins(additionalPlugins.split(','));
+      installHelmPlugins(additionalPlugins.split(',').map(str => str.trim());
     }
     installHelmfile(core.getInput("helmfile-version"));
   } catch (error) {


### PR DESCRIPTION
Allow for a yaml multi line string otherwise newlines can confuse it
```
 Error: parse "\nhttps://github.com/jkroepke/helm-secrets": net/url: invalid control character in URL
```