### PR TITLE
Fix versions for diff and s3 plugins

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,11 +35,11 @@ inputs:
     required: false
   helm-diff-plugin-version:
     description: "Version of the helm diff plugin to install"
-    default: "master"
+    default: "v3.9.14"
     required: false
   helm-s3-plugin-version:
     description: "Version of the helm s3 plugin to install"
-    default: "master"
+    default: "v0.16.2"
     required: false
   additional-helm-plugins:
     description: |


### PR DESCRIPTION
This PR fixes the default versions of the helm plugins of this GH action.

This issue: https://github.com/mamezou-tech/setup-helmfile/issues/62 was caused by a breaking change in the [s3 plugin](https://github.com/hypnoglow/helm-s3/pull/487#issuecomment-2628042206). 

If plugins aren't versioned, a breaking change in the latest plugin version can take down this action. Having the defaults versioned guarantees that someone will QA the version updates before they go live