### PR TITLE
ci: add ARM runner job to verify auto-detected helmfile arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,21 @@ jobs:
         helmfile --version | grep 1.2.3
         file ~/bin/helmfile | grep x86-64
 
+  install_helmfile_on_arm_runner:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v6
+    - name: Setup helmfile
+      uses: ./
+      with:
+        install-kubectl: no
+        install-helm: no
+        install-helm-plugins: no
+    - name: Test
+      run: |
+        helmfile --version | grep 1.2.3
+        file ~/bin/helmfile | grep aarch64
+
   install_addtional_plugins:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Follow-up to #84: CI only exercised `amd64` (either via default or explicit `helmfile-arch: amd64`), so the auto-detection path on an actual ARM runner was never verified end-to-end.
- Adds `install_helmfile_on_arm_runner`, running on `ubuntu-24.04-arm` with `helmfile-arch` left unset, confirming the installed binary is `aarch64`.

## Test plan
- [x] CI passes on this PR, including the new ARM job